### PR TITLE
bump alpine to 3.11, configurable port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 
-FROM alpine:3.5
+FROM alpine:3.11
 
 RUN apk add --no-cache openssh; \
     adduser -D user; mkdir /home/user/.ssh; chown user:user /home/user/.ssh; chmod 0700 /home/user/.ssh; \
     touch /home/user/.ssh/authorized_keys; chown user:user /home/user/.ssh/authorized_keys
     
 ADD entrypoint.sh /entrypoint.sh
-    
-EXPOSE 22
+
+ARG SSHD_PORT=22
+ENV SSHD_PORT=$SSHD_PORT
+
+EXPOSE $SSHD_PORT
 CMD    ["sh", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Launch the docker container on your server:
 
     docker run -d -p 443:22 -e "USER_SSH_ALLOWED=*paste your ssh key here*" nicolasvan/ssh-socks-tunnel
 
-In the above example we redirect the 22 port to 443 (HTTPS port) on our host. The reason is that the hellish enterprise proxies we try to work around will always disallow connections to all ports except that HTTPS port. We also add some ssh key(s) to allow a safe connexion to our SSH server.
+In the above example we redirect the 22 port to 443 (HTTPS port) on our host.
+The reason is that the hellish enterprise proxies we try to work around will always disallow connections to all ports except that HTTPS port.
+We also add some ssh key(s) to allow a safe connexion to our SSH server.
+
+As an alternative to redirecting/mapping the port via docker (e.g. for some scenarios like [Azure Container Instances](https://azure.microsoft.com/en-us/services/container-instances/) the optional environment variable `SSHD_PORT` can be used.
 
 Then create a SOCKS proxy to test:
 
@@ -22,7 +26,7 @@ Then create a SOCKS proxy to test:
     
 Configure your browser to connect to the `localhost:1234` SOCKS proxy and test that everything works fine. You can check on [What is my ip](http://whatismyipaddress.com/) that it's your server IP which is displayed.
 
-The last thing to do before going to work tomorrow is to install [corkscrew](http://agroman.net/corkscrew/) on your local machine. You can't configure it right now but you may not be able to download it at work, so do it in advance.
+The last thing to do before going to work tomorrow is to install [corkscrew](https://github.com/bryanpkc/corkscrew) on your local machine. You can't configure it right now but you may not be able to download it at work, so do it in advance.
 
 While at work
 -------------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In the above example we redirect the 22 port to 443 (HTTPS port) on our host.
 The reason is that the hellish enterprise proxies we try to work around will always disallow connections to all ports except that HTTPS port.
 We also add some ssh key(s) to allow a safe connexion to our SSH server.
 
-As an alternative to redirecting/mapping the port via docker (e.g. for some scenarios like [Azure Container Instances](https://azure.microsoft.com/en-us/services/container-instances/) the optional environment variable `SSHD_PORT` can be used.
+As an alternative to redirecting/mapping the port via docker the optional environment variable `SSHD_PORT` can be used. (e.g. for some scenarios like [Azure Container Instances](https://azure.microsoft.com/en-us/services/container-instances/))
 
 Then create a SOCKS proxy to test:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ fi
 echo "State of /home/user/.ssh/authorized_keys :"
 cat /home/user/.ssh/authorized_keys
 
-exec /usr/sbin/sshd -D -e
+exec /usr/sbin/sshd -p "${SSHD_PORT}" -D -e


### PR DESCRIPTION
- change alpine from 3.5 to 3.11
- allow build- and run-time configuration of SSHD_PORT